### PR TITLE
Rename 168x144 display to 144x168

### DIFF
--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -34,7 +34,7 @@ Implementation Notes
 
 **Hardware:**
 
-* `Adafruit SHARP Memory Display Breakout - 1.3 inch 168x144 Monochrome <https://www.adafruit.com/product/3502>`_
+* `Adafruit SHARP Memory Display Breakout - 1.3 inch 144x168 Monochrome <https://www.adafruit.com/product/3502>`_
 
 * `Adafruit SHARP Memory Display Breakout - 1.3 inch 96x96 Monochrome <https://www.adafruit.com/product/1393>`_
 


### PR DESCRIPTION
That display has a vertical alignment, so 144 has to be specified as
width and 168 as height, otherwise the display is mangled.

Fix #3