### PR TITLE
Added image function that uses numpy if available

### DIFF
--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -128,9 +128,11 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
                     width, height
                 )
             )
-        
+
         if numpy:
-            self.buffer = bytearray(numpy.packbits(numpy.asarray(img), axis=1).flatten().tolist())
+            self.buffer = bytearray(
+                numpy.packbits(numpy.asarray(img), axis=1).flatten().tolist()
+            )
         else:
             # Grab all the pixels from the image, faster than getpixel.
             pixels = img.load()
@@ -144,5 +146,3 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
                         self.pixel(x, y, pixels[(x, y)])
                     elif pixels[(x, y)]:
                         self.pixel(x, y, 1)  # only write if pixel is true
-
-


### PR DESCRIPTION
Using the `display.image(image)` function to convert a PIL image to the proper format to display is *very* slow. See [here](https://forums.adafruit.com/viewtopic.php?f=47&t=185907) for a thread with information on the issue. Using numpy to convert the image data is quite a bit faster. I measured the time to call the `display.image(image)` with the current method, and with numpy. The execution time decreased from ~7.1sec to .014sec on a Raspberry Pi Zero W.

Similar to [this](https://github.com/adafruit/Adafruit_CircuitPython_RGB_Display/blob/main/adafruit_rgb_display/rgb.py) function, I added a check for numpy to the code, and if it is available, numpy is used to generate the frame data. If numpy is not available, the function should work the same way as before.