### PR TITLE
Limit the number of writes to improve performance

### DIFF
--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -98,8 +98,7 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
             for line in range(self.height):
                 self._buf[0] = reverse_bit(line + 1)
                 image_buffer.extend(self._buf)
-                image_buffer.extend(
-                    self.buffer[slice_from: slice_from + line_len])
+                image_buffer.extend(self.buffer[slice_from : slice_from + line_len])
                 slice_from += line_len
                 self._buf[0] = 0
                 image_buffer.extend(self._buf)

--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -28,9 +28,9 @@ Implementation Notes
 """
 # pylint: enable=line-too-long
 
-from micropython import const
 import adafruit_framebuf
 from adafruit_bus_device.spi_device import SPIDevice
+from micropython import const
 
 try:
     import numpy
@@ -85,23 +85,26 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
 
         with self.spi_device as spi:
 
+            _imageBuf = bytearray()
             # toggle the VCOM bit
             self._buf[0] = _SHARPMEM_BIT_WRITECMD
             if self._vcom:
                 self._buf[0] |= _SHARPMEM_BIT_VCOM
             self._vcom = not self._vcom
-            spi.write(self._buf)
+            _imageBuf.extend(self._buf)
 
             slice_from = 0
             line_len = self.width // 8
             for line in range(self.height):
                 self._buf[0] = reverse_bit(line + 1)
-                spi.write(self._buf)
-                spi.write(memoryview(self.buffer[slice_from : slice_from + line_len]))
+                _imageBuf.extend(self._buf)
+                _imageBuf.extend(
+                    self.buffer[slice_from: slice_from + line_len])
                 slice_from += line_len
                 self._buf[0] = 0
-                spi.write(self._buf)
-            spi.write(self._buf)  # we send one last 0 byte
+                _imageBuf.extend(self._buf)
+            _imageBuf.extend(self._buf)
+            spi.write(_imageBuf)
 
     def image(self, img):
         """Set buffer to value of Python Imaging Library image.  The image should
@@ -135,7 +138,7 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
                 self.buf[i] = 0
             # Iterate through the pixels
             for x in range(width):  # yes this double loop is slow,
-                for y in range(height):  #  but these displays are small!
+                for y in range(height):  # but these displays are small!
                     if img.mode == "RGB":
                         self.pixel(x, y, pixels[(x, y)])
                     elif pixels[(x, y)]:

--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -85,26 +85,26 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
 
         with self.spi_device as spi:
 
-            _imageBuf = bytearray()
+            image_buffer = bytearray()
             # toggle the VCOM bit
             self._buf[0] = _SHARPMEM_BIT_WRITECMD
             if self._vcom:
                 self._buf[0] |= _SHARPMEM_BIT_VCOM
             self._vcom = not self._vcom
-            _imageBuf.extend(self._buf)
+            image_buffer.extend(self._buf)
 
             slice_from = 0
             line_len = self.width // 8
             for line in range(self.height):
                 self._buf[0] = reverse_bit(line + 1)
-                _imageBuf.extend(self._buf)
-                _imageBuf.extend(
+                image_buffer.extend(self._buf)
+                image_buffer.extend(
                     self.buffer[slice_from: slice_from + line_len])
                 slice_from += line_len
                 self._buf[0] = 0
-                _imageBuf.extend(self._buf)
-            _imageBuf.extend(self._buf)
-            spi.write(_imageBuf)
+                image_buffer.extend(self._buf)
+            image_buffer.extend(self._buf)
+            spi.write(image_buffer)
 
     def image(self, img):
         """Set buffer to value of Python Imaging Library image.  The image should


### PR DESCRIPTION
The current `dispaly.show()` command is very slow and takes roughly a second to complete. I discovered from [this](https://forums.adafruit.com/viewtopic.php?f=47&t=185907) thread that it's likely due to the Linux scheduler limiting how fast one can send data to the SPI hardware. To overcome this issue we now do a single write command. This significantly improves the performance which makes for a nearly instant screen response.

This resolves https://github.com/adafruit/Adafruit_CircuitPython_SharpMemoryDisplay/issues/18