### PR TITLE
added typing for image, scs, and, reverse_bit num

### DIFF
--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -33,7 +33,9 @@ from adafruit_bus_device.spi_device import SPIDevice
 from micropython import const
 
 try:
+    from PIL import Image
     import numpy
+    from digitalio import DigitalInOut
 except ImportError:
     numpy = None
 
@@ -45,7 +47,7 @@ _SHARPMEM_BIT_VCOM = const(0x40)  # in lsb
 _SHARPMEM_BIT_CLEAR = const(0x20)  # in lsb
 
 
-def reverse_bit(num):
+def reverse_bit(num: float):
     """Turn an LSB byte to an MSB byte, and vice versa. Used for SPI as
     it is LSB for the SHARP, but 99% of SPI implementations are MSB only!"""
     result = 0
@@ -62,7 +64,15 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
 
     # pylint: disable=too-many-instance-attributes,abstract-method
 
-    def __init__(self, spi, scs_pin, width, height, *, baudrate=2000000):
+    def __init__(
+        self,
+        spi: SPIDevice,
+        scs_pin: DigitalInOut,
+        width: float,
+        height: float,
+        *,
+        baudrate=2000000
+    ):
         scs_pin.switch_to_output(value=True)
         self.spi_device = SPIDevice(
             spi, scs_pin, cs_active_value=True, baudrate=baudrate
@@ -105,7 +115,7 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
             image_buffer.extend(self._buf)
             spi.write(image_buffer)
 
-    def image(self, img):
+    def image(self, img: Image):
         """Set buffer to value of Python Imaging Library image.  The image should
         be in 1 bit mode and a size equal to the display size."""
         # determine our effective width/height, taking rotation into account

--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -27,6 +27,7 @@ Implementation Notes
 
 """
 # pylint: enable=line-too-long
+from __future__ import annotations
 
 import adafruit_framebuf
 from adafruit_bus_device.spi_device import SPIDevice
@@ -71,7 +72,7 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
         width: float,
         height: float,
         *,
-        baudrate=2000000
+        baudrate=2000000,
     ):
         scs_pin.switch_to_output(value=True)
         self.spi_device = SPIDevice(

--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -27,10 +27,10 @@ Implementation Notes
 
 """
 # pylint: enable=line-too-long
+from __future__ import annotations
 
 
 try:
-    from __future__ import annotations
     from busio import SPI
     from digitalio import DigitalInOut
     from circuitpython_typing.pil import Image

--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 
 try:
+    # pylint: disable=unused-import
+    import typing
     from busio import SPI
     from digitalio import DigitalInOut
     from circuitpython_typing.pil import Image

--- a/adafruit_sharpmemorydisplay.py
+++ b/adafruit_sharpmemorydisplay.py
@@ -27,16 +27,22 @@ Implementation Notes
 
 """
 # pylint: enable=line-too-long
-from __future__ import annotations
+
+
+try:
+    from __future__ import annotations
+    from busio import SPI
+    from digitalio import DigitalInOut
+    from circuitpython_typing.pil import Image
+except ImportError:
+    pass
 
 import adafruit_framebuf
 from adafruit_bus_device.spi_device import SPIDevice
 from micropython import const
 
 try:
-    from PIL import Image
     import numpy
-    from digitalio import DigitalInOut
 except ImportError:
     numpy = None
 
@@ -48,7 +54,7 @@ _SHARPMEM_BIT_VCOM = const(0x40)  # in lsb
 _SHARPMEM_BIT_CLEAR = const(0x20)  # in lsb
 
 
-def reverse_bit(num: float):
+def reverse_bit(num: int) -> int:
     """Turn an LSB byte to an MSB byte, and vice versa. Used for SPI as
     it is LSB for the SHARP, but 99% of SPI implementations are MSB only!"""
     result = 0
@@ -67,10 +73,10 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
 
     def __init__(
         self,
-        spi: SPIDevice,
+        spi: SPI,
         scs_pin: DigitalInOut,
-        width: float,
-        height: float,
+        width: int,
+        height: int,
         *,
         baudrate=2000000,
     ):
@@ -89,7 +95,7 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
         # Set the vcom bit to a defined state
         self._vcom = True
 
-    def show(self):
+    def show(self) -> None:
         """write out the frame buffer via SPI, we use MSB SPI only so some
         bit-swapping is required.
         """
@@ -116,7 +122,7 @@ class SharpMemoryDisplay(adafruit_framebuf.FrameBuffer):
             image_buffer.extend(self._buf)
             spi.write(image_buffer)
 
-    def image(self, img: Image):
+    def image(self, img: Image) -> None:
         """Set buffer to value of Python Imaging Library image.  The image should
         be in 1 bit mode and a size equal to the display size."""
         # determine our effective width/height, taking rotation into account


### PR DESCRIPTION
Added typing for the SharpMemoryDisplay. Should close issue: https://github.com/adafruit/Adafruit_CircuitPython_SharpMemoryDisplay/issues/17